### PR TITLE
Små rettelser

### DIFF
--- a/data.json
+++ b/data.json
@@ -57,20 +57,6 @@
         ]
     },
     {
-        "name": "Fullrate",
-        "url": "https:\/\/www.fullrate.dk",
-        "ipv6": true,
-        "comment": "Har implementeret IPv6 underst\u00f8ttelse. Ikke alle routere er underst\u00f8ttet.",
-        "partial": true,
-        "sources": [
-            {
-                "date": "2015-10-11",
-                "name": "v2.dk",
-                "url": "https:\/\/www.version2.dk\/comment\/316818#comment-316818"
-            }
-        ]
-    },
-    {
         "name": "Telia",
         "url": "https:\/\/www.telia.dk\/privat\/",
         "ipv6": true,

--- a/data.json
+++ b/data.json
@@ -42,7 +42,7 @@
         ]
     },
     {
-        "name": "TDC Erhvev",
+        "name": "TDC Erhverv",
         "url": "https:\/\/tdc.dk",
         "ipv6": true,
         "comment": "Leverer IPv6 til erhverv p\u00e5 professionelle fiberl\u00f8sninger.",

--- a/data.json
+++ b/data.json
@@ -207,20 +207,6 @@
         ]
     },
     {
-        "name": "Verdo",
-        "url": "https:\/\/verdo.dk\/",
-        "ipv6": false,
-        "comment": "Vi har planer om at udbyde det, men har p\u00e5 nuv\u00e6rende tidspunkt ingen tidshorisont for det.",
-        "partial": false,
-        "sources": [
-            {
-                "date": "2015-11-26",
-                "name": "ISP",
-                "url": null
-            }
-        ]
-    },
-    {
         "name": "Sentia",
         "url": "https:\/\/sentia.com\/dk\/",
         "ipv6": true,


### PR DESCRIPTION
Verdo Tele A/S findes ikke længere, kunderne er rykket over til Stofa.

TDC Erhvervs stavefejl er fixed.

Fullrate er nu YouSee, og derved ingen grund til at liste den længere.