### PR TITLE
Update URL for Forskningsnettet

### DIFF
--- a/data.json
+++ b/data.json
@@ -596,7 +596,7 @@
             {
                 "date": "2017-02-06",
                 "name": "ISP",
-                "url": "https:\/\/www.deic.dk\/IPv6"
+                "url": "https:\/\/www.deic.dk\/da\/IPv6"
             }
         ]
     },


### PR DESCRIPTION
Ny URL er https://www.deic.dk/da/IPv6