### PR TITLE
Opdater status hos Fibia

### DIFF
--- a/data.json
+++ b/data.json
@@ -362,11 +362,11 @@
         "name": "Fibia",
         "url": "https:\/\/www.fibia.dk",
         "ipv6": false,
-        "comment": "Vi har IPv6 med i vores planer, dog er der ikke givet nogen tidshorisont endnu.",
+        "comment": "Vi arbejder på at understøtte IPv6, dog er der ikke givet nogen tidshorisont endnu.",
         "partial": false,
         "sources": [
             {
-                "date": "2020-03-25",
+                "date": "2021-04-08",
                 "name": "ISP",
                 "url": null
             }


### PR DESCRIPTION
Opfølgning på #19

Jeg har skrevet og hørt om Fibia har en opdatering. Jeg fik følgende besked tilbage:
```
Der arbejdes desværre fortsat på understøttelse af IPv6, og ligeså snart vi er klar, så ville det blive meldt ud.
```


Sidste år lød det som om de havde planer for IPv6, i år lyder det som om de er i gang med det. Jeg har redigeret beskeden til at reflektere ændringen :)