### PR TITLE
Opdatér Kviknets beskrivelse

### DIFF
--- a/data/kviknet.json
+++ b/data/kviknet.json
@@ -2,15 +2,24 @@
   "name": "Kviknet",
   "url": "https://www.kviknet.dk",
   "ipv6": true,
-  "comment": "Vi understøtter IPv6 på fiber til erhverv og boligforeninger samt til xDSL-kunder på eBSA platformen. Leverer IPv6 via Norlys Fiber.",
+  "comment": "Vi understøtter IPv6 på alle andre forbindelser end COAX på nuværende tidspunkt. COAX er desværre begrænset af TDC.",
   "partial": true,
   "private": true,
   "sources": [
+    {
+      "date": "2021-11-17",
+      "name": "Email",
+      "url": "https://github.com/emilstahl/ipv6/issues/48"
+    },
     {
       "date": "2020-10-01",
       "name": "ISP",
       "url": "https://www.kviknet.dk/produktinfo/fiber_norlys"
     },
-    { "date": "2016-10-28", "name": "ISP", "url": "https://v2.dk/1011318" }
+    {
+      "date": "2016-10-28",
+      "name": "ISP",
+      "url": "https://v2.dk/1011318"
+    }
   ]
 }


### PR DESCRIPTION
Løser issue #48.

@eyJhb skriver følgende:
> @emilstahl har lige været i kontakt med Kviknet over e-mail, hvor de siger følgende.
> 
> > Vi understøtter IPv6 på alle andre forbindelser end COAX på nuværende tidspunkt.
> > COAX er desværre begrænset af TDC.
> 
> Ved ikke hvordan at det lige skal håndteres ift. de `.json` filer, når at det er via. en e-mail :) Kan du guide mig her, eller ændre det?