### PR TITLE
Update fastspeed.json

### DIFF
--- a/data/fastspeed.json
+++ b/data/fastspeed.json
@@ -2,7 +2,7 @@
   "name": "Fastspeed (og JETNET)",
   "url": "https://fastspeed.dk",
   "ipv6": true,
-  "comment": "Vi kører med IPv6 på vores fiberforbindelser. Der arbejdes på at få IPv6 på vores coaxforbindelser.",
+  "comment": "Vi kører med IPv6 på vores fiberforbindelser (med undtagelse af forbindelser på Aura's net). Der arbejdes på at få IPv6 på vores coaxforbindelser.",
   "partial": true,
   "private": true,
   "sources": [{ "date": "2020-04-28", "name": "ISP", "url": null }]


### PR DESCRIPTION
Fastspeed har bekræftet telefonisk over for mig at de ikke kan tilbyde IPv6 til kunder på Aura’s net.