### PR TITLE
GlobalConnect NN A/S - Opløst efter fusion

### DIFF
--- a/data/globalconnect-nn.json
+++ b/data/globalconnect-nn.json
@@ -1,9 +1,0 @@
-{
-  "name": "GlobalConnect NN (tidl. Nianet)",
-  "url": "https://www.globalconnect.dk",
-  "ipv6": true,
-  "comment": "Vi understøtter IPv6 (ikke på SE/Stofa’s net). Leverer kun til erhvervskunder.",
-  "partial": true,
-  "business": true,
-  "sources": [{ "date": "2015-12-11", "name": "ISP", "url": null }]
-}


### PR DESCRIPTION
Kilde: https://datacvr.virk.dk/enhed/virksomhed/27172776