### PR TITLE
doc: stofa: streamline comment field

### DIFF
--- a/data/stofa.json
+++ b/data/stofa.json
@@ -3,7 +3,18 @@
   "name": "Stofa - en del af Norlys",
   "url": "https://stofa.dk",
   "ipv6": true,
-  "comment": "Erhvervskunder og privatkunder på fiber har mulighed for IPv6, en del forbrugere aktiveret pr. default. Ingen IPv6-understøttelse på coax. xDSL (kobber) ukendt",
+  "comment": "Erhvervskunder og privatkunder på fiber har mulighed for IPv6, en del forbrugere aktiveret pr. default. IPv6 på COAX forbindelser understøttes ikke af TDC. xDSL (kobber) ukendt",
   "partial": true,
-  "sources": [{"date": "2022-08-18", "name": "ISP", "url": null}, { "date": "2021-12-10", "name": "ISP", "url": null }]
+  "sources": [
+    {
+      "date": "2022-08-18",
+      "name": "ISP",
+      "url": null
+    },
+    {
+      "date": "2021-12-10",
+      "name": "ISP",
+      "url": null
+    }
+  ]
 }


### PR DESCRIPTION
Ligesom i #61. Ensret wording for COAX understøttelse af IPv6. Da
ingen 3rd-party leverandører kan understøtte IPv6 på TDC COAX. Ej
heller TDC eller deres datterselskaber.