### PR TITLE
Update dansk-kabel tv.json

### DIFF
--- a/data/dansk-kabel tv.json
+++ b/data/dansk-kabel tv.json
@@ -5,5 +5,5 @@
   "ipv6": false,
   "comment": "De kan på nuværende tidspunkt, ikke oplyse om de kommer til at tilbyde IPv6, på et senere tidspunkt.",
   "partial": false,
-  "sources": [{ "date": "2023-04-23", "name": "ISP", "url": null }]
+  "sources": [{ "date": "2023-04-20", "name": "ISP", "url": null }]
 }

--- a/data/dansk-kabel tv.json
+++ b/data/dansk-kabel tv.json
@@ -3,7 +3,7 @@
   "name": "Dansk Kabel TV",
   "url": "https://www.danskkabeltv.dk",
   "ipv6": false,
-  "comment": "IPv6 i vores bolignet er noget vi tester og bestræber os på at kunne levere i fremtiden. Ingen tidshorisont.",
+  "comment": "De kan på nuværende tidspunkt, ikke oplyse om de kommer til at tilbyde IPv6, på et senere tidspunkt.",
   "partial": false,
-  "sources": [{ "date": "2015-08-23", "name": "ISP", "url": null }]
+  "sources": [{ "date": "2023-04-23", "name": "ISP", "url": null }]
 }


### PR DESCRIPTION
Dansk Kabel TV support oplyser:

> Vi tilbyder desværre ikke IPv6.
> Jeg kan desværre ikke svare på om vi kommer til at tilbyde det på et senere tidspunkt.
