### PR TITLE
Ingen IPv6 for Stofa privatkunder

### DIFF
--- a/data/stofa.json
+++ b/data/stofa.json
@@ -3,11 +3,11 @@
   "name": "Stofa - en del af Norlys",
   "url": "https://stofa.dk",
   "ipv6": true,
-  "comment": "Erhvervskunder og privatkunder på fiber har mulighed for IPv6, en del forbrugere aktiveret pr. default. IPv6 på COAX forbindelser understøttes ikke af TDC. xDSL (kobber) ukendt",
+  "comment": "Erhvervskunder på fiber har mulighed for IPv6, en del aktiveret pr. default. IPv6 er på vej til privatkunder, men der er ikke givet en tidshorisont endnu. IPv6 på COAX forbindelser understøttes ikke af TDC. xDSL (kobber) ukendt",
   "partial": true,
   "sources": [
     {
-      "date": "2022-08-18",
+      "date": "2023-07-14",
       "name": "ISP",
       "url": null
     },


### PR DESCRIPTION
Jeg har lige snakket med Stofa support, som informerer mig om at IPv6 ikke er tilgængeligt for privatkunder.

@amatzen skrev i 66e0914 at IPv6 er tilgængelig for privatkunder, men den medarbejder jeg snakkede med forsikrede mig om at det ikke var sandt, og dobbelttjekkede også med en tekniker. @amatzen har du måske skrevet det ved en fejl, eller kan du dele hvor du fik din information fra?