### PR TITLE
Ingen statisk IPv6 prefix fra Altibox 

### DIFF
--- a/data/altibox.json
+++ b/data/altibox.json
@@ -2,8 +2,8 @@
   "$schema": "./../schema.json",
   "name": "Altibox",
   "url": "https://www.altibox.dk",
-  "ipv6": true,
-  "comment": "Vi understøtter IPv6rd.",
-  "partial": false,
-  "sources": [{ "date": "2016-01-25", "name": "ISP", "url": null }]
+  "ipv6": false,
+  "comment": "Vi tilbyder ikke på nuværende tidspunkt statisk tildeling af IPv6 prefix/adresser.",
+  "partial": true,
+  "sources": [{ "date": "2023-11-06", "name": "ISP (Email)", "url": null }]
 }


### PR DESCRIPTION
Efter at have talt med kundesupport fra Altibox Danmark A/S kan jeg desværre konkludere, at Altibox Danmark på nuværende tidspunkt ikke tilbyder statisk [IPv6 prefix](https://github.com/onemarcfifty/cheat-sheets/blob/main/networking/ipv6.md#subnetting). Et uddrag fra e-mailen kan ses herunder:

> Hej Mikkel
> Jeg har gravet lidt dybere i sagen, og må desværre konkluderer at vi på nuværende tidspunkt ikke tilbyder statisk tildeling af IPv6 prefix/adresser.
> Jeg mistænker at IP-adresserne har ændret sig i takt med skiftet fra /64 til /56 subnet. Prefixet vil dog forblive jeres så længe at udstyret ikke er slukket i længere tid, og/eller vedligehold på fibernettet resulterer i at vi er nødsaget til at tildele et nyt prefix.

Dog virker IPv6 fint via en dynamisk prefix samt subnets.