### PR TITLE
Altibox og Bolignet

### DIFF
--- a/data/altibox.json
+++ b/data/altibox.json
@@ -2,8 +2,8 @@
   "$schema": "./../schema.json",
   "name": "Altibox",
   "url": "https://www.altibox.dk",
-  "ipv6": false,
-  "comment": "Vi tilbyder ikke på nuværende tidspunkt statisk tildeling af IPv6 prefix/adresser.",
-  "partial": true,
-  "sources": [{ "date": "2023-11-06", "name": "ISP (Email)", "url": "https://user-images.githubusercontent.com/71432330/280961438-cad75111-2f1f-4215-862b-4b26e44c6dca.png" }]
+  "ipv6": true,
+  "comment": "Fuld understøttelse for Ipv6.",
+  "partial": false,
+  "sources": [{ "date": "2024-02-19", "name": "Website", "url": "https://minesider.altibox.dk/sadan-kommer-du-i-gang-med-ipv6/" }]
 }

--- a/data/bolignet.json
+++ b/data/bolignet.json
@@ -3,7 +3,7 @@
   "name": "bolig:net",
   "url": "https://www.bolignet.dk",
   "ipv6": true,
-  "comment": "Understøtter IPv6 Prefix Delegation.",
+  "comment": "Understøtter IPv6 Prefix Delegation (mod merbetaling)",
   "partial": false,
   "sources": [
     {


### PR DESCRIPTION
1. Bolignet opkræver betaling for oprettelse af IPv6 og derefter også betaling pr måned. Det synes jeg burde fremgå af hjemmesiden.
2. Altibox har fuld understøttelse for ipv6 nu. Prefix-størrelse er jeg i tvivl om, men jeg har fået et /56. 