### PR TITLE
Altibox. Ingen IPv6 RD eller statisk prefix

### DIFF
--- a/data/altibox.json
+++ b/data/altibox.json
@@ -2,8 +2,8 @@
   "$schema": "./../schema.json",
   "name": "Altibox",
   "url": "https://www.altibox.dk",
-  "ipv6": true,
-  "comment": "Fuld understøttelse for Ipv6.",
-  "partial": false,
-  "sources": [{ "date": "2024-02-19", "name": "Website", "url": "https://minesider.altibox.dk/sadan-kommer-du-i-gang-med-ipv6/" }]
+  "ipv6": false,
+  "comment": "Ingen statisk IPv6 prefix. Dog Dual Stack.",
+  "partial": true,
+  "sources": [{ "date": "2023-11-08", "name": "ISP (Email)", "url": null }]
 }


### PR DESCRIPTION
Jeg ville ønske at jeg havde ret med denne  [PR](https://github.com/emilstahl/ipv6/pull/108), men Altibox tilbyder ikke længere IPv6 Rapid Deployment. De tilbyder hellere ikke statisk IPv6 prefix (Se [PR](https://github.com/emilstahl/ipv6/pull/100)). 

![image](https://github.com/emilstahl/ipv6/assets/71432330/0211914d-8f07-4b67-85e0-e9ce4204876e)

Jeg har en forudsætning om at Altibox ikke tilbyder den samme service af IPv6 i hele landet, da jeg personligt i Aalborg ikke har nogen IPv6 forbindelse. Jeg er dog pt i kontakt med Altibox om at få løst problemet.