### PR TITLE
Update aura.json

### DIFF
--- a/data/aura.json
+++ b/data/aura.json
@@ -3,9 +3,10 @@
   "name": "AURA",
   "url": "https://www.aura.dk",
   "ipv6": false,
-  "comment": "Vi har umiddelbart den fornødne infrastruktur til at understøtte IPv6 - såfremt dette bliver aktuelt. Vi har ikke for nærverende planer om at indføre IPv6 i vores net.",
+  "comment": "…i forhold til dit spørgsmål så har vi ikke planer om at få IPV6 til privat kunder da vi ikke har nok kunder i vores område til at det kan betale sig",
   "partial": false,
   "sources": [
+    { "date": "2024-02-01", "name": "ISP", "url": null },
     { "date": "2018-10-26", "name": "ISP", "url": null },
     { "date": "2016-12-21", "name": "ISP", "url": null }
   ]


### PR DESCRIPTION
Oprettede en sag ved Aura Fiber kundeservice med følgende ordlyd
> Hej.
> Jeg er meget interesseret i at høre om jeres planer for IPv6 udrulning til jeres private kunder. Spørgsmålet mener jeg er blevet relevant endnu en gang, da hosting udbydere som AWS er begyndt at tage flere penge for at tilbyde IPv4 til deres kunder, https://aws.amazon.com/blogs/aws/new-aws-public-ipv4-address-charge-public-ip-insights/. En IPv4 skat, som der kun er én til at betale: slutbrugeren. Det er almindeligt kendt at der er differentierede priser til kunder med gammel teknologi. Eksempelvis har der siden 2012 været eksempler på ekstra gebyrer til brugere med Internet Explorer 7, https://www.kogan.com/au/blog/new-internet-explorer-7-tax/. Ser frem til at høre jeres svar.
> Med venlig hilsen
> Martin Westergaard Lassen

Og fik følgende svar
> i forhold til dit spørgsmål så har vi ikke planer om at få IPV6 til privat kunder da vi ikke har nok kunder i vores område til at det kan betale sig

… Lettere nedslående.