### PR TITLE
Altibox har fuld IPv6-understøttelse

### DIFF
--- a/data/altibox.json
+++ b/data/altibox.json
@@ -2,8 +2,8 @@
   "$schema": "./../schema.json",
   "name": "Altibox",
   "url": "https://www.altibox.dk",
-  "ipv6": false,
-  "comment": "Ingen statisk IPv6 prefix. Dog Dual Stack.",
-  "partial": true,
-  "sources": [{ "date": "2023-11-08", "name": "ISP (Email)", "url": null }]
+  "ipv6": true,
+  "comment": "Fuld understøttelse for Ipv6.",
+  "partial": false,
+  "sources": [{ "date": "2024-02-19", "name": "Website", "url": "https://minesider.altibox.dk/sadan-kommer-du-i-gang-med-ipv6/" }]
 }

--- a/data/altibox.json
+++ b/data/altibox.json
@@ -3,7 +3,7 @@
   "name": "Altibox",
   "url": "https://www.altibox.dk",
   "ipv6": true,
-  "comment": "Fuld understøttelse for Ipv6.",
+  "comment": "Ingen mulighed for statiske IPv6 prefixes.",
   "partial": false,
-  "sources": [{ "date": "2024-02-19", "name": "Website", "url": "https://minesider.altibox.dk/sadan-kommer-du-i-gang-med-ipv6/" }]
+  "sources": [{ "date": "2024-03-18", "name": "Website", "url": "https://www.altibox.dk/kundeservice/internet" }]
 }


### PR DESCRIPTION
> Tilbyder Altibox IPv6?
> Ja, det sker helt automatisk.

https://www.altibox.dk/kundeservice/internet