### PR TITLE
Add Glentevejs Antennelaug

### DIFF
--- a/data/glentevejs-antennelaug.json
+++ b/data/glentevejs-antennelaug.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "./../schema.json",
+  "name": "Glentevejs Antennelaug",
+  "url": "https://www.glenten.dk",
+  "ipv6": false,
+  "comment": "[...]der fortsættes med IPv4. Der er ved at blive nået en grænse. Derfor deles samme IP-adresse, hvilket kan resultere i, at nettet kører langsommere. Udstyret kan sagtens klare en opgradering til IPv6[...]",
+  "partial": false,
+  "sources": [
+    {
+      "date": "2019-02-07",
+      "name": "Referat af repræsentantskabsmøde",
+      "url": "https://www.glenten.dk/filarkiv/Bestyrelse/Referater/Reprasentantskab/Referat_reprasentantskabsmode_20190207_Glenten_FINAL.pdf"
+    }
+  ]
+}


### PR DESCRIPTION
Glentevejs Antennelaug understøtter ikke IPv6.

Jeg har dem som internetudbyder og kan bekræfte, at pr. 2024-08-16 har jeg kun en IPv4-adresse tildelt. Jeg kører min router i bridge-mode, men dette antager jeg ikke gør nogen forskel.

Jeg har fundet et referat fra et Glenten-repræsentantskabsmøde som kilde, men var lidt i tvivl om, hvordan jeg skulle citere, da udtalelsen var lidt længere.

Jeg håber, min PR er nyttig. Sig endelig til, hvis der er noget, jeg skal ændre i den!