### PR TITLE
Tilføjelse af Ringsted Net

### DIFF
--- a/data/ringsted-net
+++ b/data/ringsted-net
@@ -1,0 +1,10 @@
+{
+  "$schema": "./../schema.json",
+  "name": "Ringsted Net",
+  "url": "https://www.ringstednet.dk",
+  "ipv6": true,
+  "comment": "Den 4. marts 2025 overgik alle vores medlemmer til IPv6/dual stack /48 prefix-delegation.",
+  "partial": false,
+  "private": true,
+  "sources": [{ "date": "2025-03-20", "name": "ISP", "url": null }]
+}


### PR DESCRIPTION
Ringsted Net tilbyder nu alle medlemmer IPV6.