### PR TITLE
Disable Gatsby adapter auto-detection to fix Cloudflare Pages builds

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -3,6 +3,17 @@ module.exports = {
     title: "IPv6-adresse.dk",
     siteUrl: 'https://ipv6-adresse.dk'
   },
+  // Gatsby 5.12+ auto-detects a deployment adapter. Cloudflare Pages' build
+  // image is Netlify-derived, so detection installs gatsby-adapter-netlify,
+  // which then dies copying output into Netlify's /opt/build/cache (EACCES).
+  // This site is plain static output plus the _headers file that onPostBuild
+  // writes, so no adapter is needed. Declaring one skips auto-detection.
+  // `adapt` is a required func in Gatsby's config schema; the manager guards
+  // the call, so a no-op is enough.
+  adapter: {
+    name: 'none',
+    adapt: () => {},
+  },
   plugins: [
     "gatsby-plugin-sass",
     "gatsby-plugin-sitemap",


### PR DESCRIPTION
Follow-up to #134. Node is now pinned so `npm install` succeeds on Pages, but the production build still exits 1.

## Cause

Cloudflare Pages' build image is Netlify-derived — the build log shows it installing Hugo and RVM — so Gatsby 5's zero-configuration deployment detects Netlify and auto-installs its adapter:

```
success Installing Netlify adapter (gatsby-adapter-netlify@^1.2.1)
info Using gatsby-adapter-netlify adapter
...
CpyError: Cannot copy from `public/404.html` to `/opt/build/cache/cwd/public/404.html`:
Cannot create directory `/opt/build/cache/cwd/public`: EACCES: permission denied, mkdir '/opt/build/cache'
- Caused By: Error: EACCES: permission denied, mkdir '/opt/build/cache'
```

`/opt/build/cache` is Netlify's cache directory. On Pages the workspace is `/opt/buildhome`, and `/opt/build` is not writable — so the adapter fails and the build exits 1 after Gatsby has otherwise finished successfully.

## Fix

Declare an adapter in `gatsby-config.js`, which skips auto-detection entirely. Gatsby's own panic message documents this as the supported opt-out: *"configure adapter manually in gatsby-config which will skip zero-configuration deployment attempt"*.

This site does not need an adapter. It is plain static output plus the `_headers` file that `onPostBuild` generates, which is exactly what Pages consumes — and this is how the site deployed before Gatsby 5.12 introduced adapters. `adapt` is `required()` in Gatsby's joi config schema, but `adapterManager.adapt()` guards the call with `if (!adapter.adapt) return`, so a no-op function is sufficient and correct.

Keeping the fix in the repo rather than changing the Pages build image means the build behaves the same regardless of which image Pages uses.

## Verification

Local `npm run build` exits 0 and logs `info Using none adapter`. Generated `public/_headers` still contains the CSP with build-derived hashes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)