### PR TITLE
Fix truncated table headers and cramped source column

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -156,7 +156,7 @@ const IndexPage = ({ data }) => {
               {
                 id: 'state',
                 name: 'IPv6',
-                width: '35px',
+                width: '90px',
                 attributes: (cell, row) => {
                   if (cell == null) return;
                   return {
@@ -189,7 +189,7 @@ const IndexPage = ({ data }) => {
               {
                 id: 'assignedprefix',
                 name: 'Præfiks',
-                width: '35px',
+                width: '110px',
                 formatter: cell => _(<span style={{ lineHeight: 1.5 }}>{cell}</span>),
                 attributes: (cell) => {
                   if (cell == null) return;
@@ -247,7 +247,7 @@ const IndexPage = ({ data }) => {
                     );
                   })}
                 </span>),
-                width: '40px',
+                width: '110px',
               },
               {
                 id: 'sources',
@@ -273,8 +273,8 @@ const IndexPage = ({ data }) => {
                   }
                 },
 
-                
-                width: '60px',
+
+                width: '120px',
               }
             ]}
 

--- a/src/styles/index.style.scss
+++ b/src/styles/index.style.scss
@@ -19,6 +19,14 @@
     }
 }
 
+// gridjs mermaid theme clips header text with ellipsis; let it render fully
+th.gridjs-th .gridjs-th-content,
+th.gridjs-th-sort .gridjs-th-content {
+    overflow: visible;
+    text-overflow: clip;
+    width: auto;
+}
+
 blockquote {
     color: white;
     padding: 0px;


### PR DESCRIPTION
## Summary
- Table headers "IPv6", "Præfiks" and "Opdateret" rendered as "IP…"/"Pr…" — column widths (35–60px) were smaller than header text + sort arrow. Widened to 90–120px.
- gridjs' mermaid theme additionally clips header text with `overflow: hidden; text-overflow: ellipsis` regardless of column width — added a CSS override so headers render fully.
- Wider "Kilde" column also stops source links (e.g. "Blog (sigmablue.dk)") crowding into the date column.

## Test plan
- Verified in local `gatsby develop`: all six headers untruncated (checked `scrollWidth <= clientWidth` per header)
- `npm test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)