### PR TITLE
Ignore .claude/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ node_modules/
 .cache/
 public
 .idea
+.claude/
 .tmp-home/
 addrinfo.php
 security-report.md


### PR DESCRIPTION
`.claude/` was untracked but not ignored, so it showed up in every `git status` and was one careless `git add` away from being committed.

Contains `launch.json` (a `npm run develop` run config). If you'd rather share that with contributors than ignore it, the alternative is committing the file and ignoring only local state — say so and I'll swap this for `!.claude/launch.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)