### PR TITLE
Fix positional column coupling, correct the Node floor, drop a dead override

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,4 +30,4 @@ npm run develop   # dev-server på localhost:8000
 npm run build     # produktion — genererer også public/_headers (CSP m.m.)
 ```
 
-Kræver Node 20+.
+Kræver Node 20.19+ (`sass` sætter den nedre grænse). CI og deploy bruger den version, der står i [`.nvmrc`](.nvmrc).

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "gatsby"
   ],
   "engines": {
-    "node": ">=20"
+    "node": ">=20.19.0"
   },
   "scripts": {
     "develop": "gatsby develop",
@@ -35,11 +35,10 @@
   },
   "overrides": {
     "loader-utils@<2": "^1.4.2",
-    "lodash": "^4.18.1",
     "json5@<2": "^1.0.2",
+    "lodash": "^4.18.1",
     "immutable": "^4.3.9",
     "sharp": "^0.35.3",
-    "brace-expansion@1": "^1.1.18",
     "resolve-url-loader": "^5.0.0",
     "postcss": "^8.5.25",
     "serialize-javascript": "^7.0.7",

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -11,6 +11,12 @@ import '../styles/index.style.scss';
 import AdoptionChart from '../components/AdoptionChart/component';
 import { safeUrl, safeDate, formatDate } from '../utils/safe';
 
+// gridjs addresses cells by position, so the hidden columns the visible
+// formatters read from are declared once here and looked up by name. Reordering
+// or adding a column can no longer feed the wrong field into an href.
+const HIDDEN_COLUMNS = ['color', 'url'];
+const hidden = name => HIDDEN_COLUMNS.indexOf(name);
+
 // Newest valid date across an ISP's sources, regardless of array order
 const newestDate = sources => sources.reduce((max, s) => {
   const d = safeDate(s.date);
@@ -106,8 +112,7 @@ const IndexPage = ({ data }) => {
           <Grid
             data={ispData}
             columns={[
-              { name: 'color', hidden: true },
-              { name: 'url', hidden: true },
+              ...HIDDEN_COLUMNS.map(name => ({ name, hidden: true })),
               {
                 id: 'name',
                 name: 'Navn',
@@ -118,7 +123,7 @@ const IndexPage = ({ data }) => {
                 },
 
                 formatter: (cell, row) => {
-                  const url = safeUrl(row.cell(1).data);
+                  const url = safeUrl(row.cell(hidden('url')).data);
                   if (!url) return cell;
 
                   return _(
@@ -142,7 +147,7 @@ const IndexPage = ({ data }) => {
                   return {
                     style: {
                       textAlign: 'center',
-                      backgroundColor: `${row.cell(0).data}`
+                      backgroundColor: `${row.cell(hidden('color')).data}`
                     },
                   }
                 },


### PR DESCRIPTION
The remaining actionable items from the audit follow-up. Three files, no behaviour change.

## The one that was a real bug

The grid formatters addressed hidden columns by literal index:

```js
const url = safeUrl(row.cell(1).data);              // "column 1 is url"
backgroundColor: `${row.cell(0).data}`              // "column 0 is color"
```

Reorder the columns, or insert one, and this silently pulls the wrong field — a colour string into an `href`, or a URL into a CSS background. Nothing would throw; the table would just be wrong. gridjs has no name-based cell access, so the fix is to derive the indices from the same array that declares the columns:

```js
const HIDDEN_COLUMNS = ['color', 'url'];
const hidden = name => HIDDEN_COLUMNS.indexOf(name);

columns={[ ...HIDDEN_COLUMNS.map(name => ({ name, hidden: true })), ... ]}
row.cell(hidden('url')).data
```

One declaration now feeds both, so they cannot drift. Resolved values are unchanged (`color` → 0, `url` → 1), which is why no output moves.

No test: the invariant holds by construction rather than by assertion, which is the entire point of the change. A test would only re-check `Array.indexOf`.

## Node floor was wrong

`engines` said `">=20"`, but the strictest engine requirement in the installed tree is **`sass` at `>=20.19.0`**. Someone following the README onto Node 20.0 hits engine warnings. `engines` and the README now both say 20.19, and the README points at `.nvmrc` for the version CI and Pages actually use, so there is one place to bump.

## Dead override removed — and two that only looked dead

Dropped `"brace-expansion@1"`. Its advisory is no longer reported at all, and removing it leaves `package-lock.json` **byte identical**, so it was resolving nothing.

I nearly removed `"loader-utils@<2"` and `"json5@<2"` with it — both target ranges the top-level installed versions (2.0.4, 2.2.3) are already outside, so they read as no-ops. Testing said otherwise:

| overrides | total | high | critical |
|---|---|---|---|
| baseline | 24 | 2 | 0 |
| minus all three | 28 | 5 | **1** |
| minus `brace-expansion@1` only | 24 | 2 | 0 |

The critical is a nested `loader-utils <1.4.1` prototype pollution that the override was pinning up. Both stay, and this is worth remembering before anyone "tidies" that block again.

## Verification

- `npm test` — 7 pass.
- `npm run build` — exit 0.
- Server-rendered stats byte-identical: `41 / 18 (44%) / 9 (22%) / 14 (34%)`.
- `npm audit` back at the 24 / 2 high / 0 critical baseline.

## Still open, and why they are not here

- **Zone `browser_cache_ttl` = 31 days** overriding the `max-age=0` that `_headers` sets for HTML. Dashboard-only for me — the API write is blocked by a permission classifier. This is the one item with actual visitor impact.
- **CSP violation reporting** — `report-to` needs a collector endpoint to point at, and there is no free Cloudflare one. Adding the directive without an endpoint does nothing, so it needs a decision on where reports should go.
- **`parknet.dk` favicon** — their site returns 403 to automated requests. Sourcing it means hand-making an image, which is not something to invent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)