### PR TITLE
Update Fibia (Waoo): no IPv6 offered or planned per August 2026 support answer

### DIFF
--- a/data/fibia.json
+++ b/data/fibia.json
@@ -1,9 +1,17 @@
 {
   "$schema": "./../schema.json",
-  "name": "Fibia Erhverv",
+  "name": "Fibia (Waoo)",
   "url": "https://www.fibia.dk",
   "ipv6": false,
-  "comment": "Vi arbejder på at understøtte IPv6 og tidshorisonten er foreløbig 2024H2.",
+  "comment": "IPv6 er ikke et produkt som vi tilbyder, da det primært er målrettet erhverv. Så du skal desværre ikke regne med at det er noget vi kommer til at tilbyde inden for nærmere fremtid. (Svar fra Waoo Teknisk Support på vegne af Fibia, der har været eneejer af Waoo siden 2021. Fibia meldte ellers i 2024 ud, at IPv6 var på vej med tidshorisont 2024H2.)",
   "partial": false,
-  "sources": [{ "date": "2024-02-05", "name": "ISP", "url": null }]
+  "sources": [
+    { "date": "2026-08-14", "name": "ISP", "url": null },
+    { "date": "2024-02-05", "name": "ISP", "url": null },
+    {
+      "date": "2021-03-26",
+      "name": "Pressemeddelelse: Fibia bliver eneejer af Waoo",
+      "url": "https://via.ritzau.dk/pressemeddelelse/13618836/fibia-bliver-eneejer-af-waoo?publisherId=13222602"
+    }
+  ]
 }


### PR DESCRIPTION
## Summary

Updates `data/fibia.json` with a fresh answer (2026-08-14) from Waoo Teknisk Support, which handles support on behalf of Fibia:

> IPv6 er ikke et produkt som vi tilbyder, da det primært er målrettet erhverv. Så du skal desværre ikke regne med at det er noget vi kommer til at tilbyde inden for nærmere fremtid.

This supersedes the stale 2024 statement that IPv6 support was slated for 2024H2.

## Changes

- Replace the 2024 comment with the new quote, plus context that Fibia has been sole owner of Waoo since 2021 and that the earlier 2024H2 timeline was never met.
- Rename the entry from **Fibia Erhverv** to **Fibia (Waoo)**, since the new answer covers the consumer brand rather than just the business arm.
- Add two sources: the 2026-08-14 ISP support answer and the [Ritzau press release](https://via.ritzau.dk/pressemeddelelse/13618836/fibia-bliver-eneejer-af-waoo?publisherId=13222602) (2021-03-26) documenting Fibia's sole ownership of Waoo. The existing 2024-02-05 ISP source is kept.

`ipv6: false` and `partial: false` are unchanged. The entry URL stays `https://www.fibia.dk`, so the existing self-hosted favicon keeps working.

## Testing

- `npm test`: 7/7 pass
- Verified the JSON conforms to `schema.json` (required fields, `YYYY-MM-DD` source dates, http(s) URL patterns)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XWu4GaSDWJyuwY1tR4458x

---
_Generated by [Claude Code](https://claude.ai/code/session_01XWu4GaSDWJyuwY1tR4458x)_