### PR TITLE
Extract page logic into tested utils, add data-quality and e2e smoke tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,3 +64,10 @@ jobs:
           test -f public/manifest.webmanifest
           grep -q "Content-Security-Policy" public/_headers
           grep -q "sha256-" public/_headers
+
+      - name: Install Playwright Chromium
+        run: npx playwright install --with-deps chromium
+
+      # Serves the build from the step above (playwright.config.js webServer)
+      - name: End-to-end smoke tests
+        run: npm run test:e2e

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 node_modules/
 .cache/
 public
+playwright-report/
+test-results/
 .idea
 .claude/
 .tmp-home/

--- a/README.md
+++ b/README.md
@@ -31,3 +31,17 @@ npm run build     # produktion — genererer også public/_headers (CSP m.m.)
 ```
 
 Kræver Node 20.19+ (`sass` sætter den nedre grænse). CI og deploy bruger den version, der står i [`.nvmrc`](.nvmrc).
+
+## Test
+
+```sh
+npm test          # unit- og datakvalitetstests (node --test) med coverage
+npm run build     # e2e-testene kører mod produktionsbygget…
+npm run test:e2e  # …serveret via `gatsby serve` (Playwright)
+```
+
+Logikken bor i små CommonJS-moduler i [`src/utils/`](src/utils/), så `node --test` kan
+køre dem uden transpilering — komponenterne er tynde skaller udenom. `test/data.test.js`
+tjekker det, JSON-skemaet ikke kan udtrykke (ægte datoer, ingen dubletter,
+`partial` kræver `ipv6`). Playwright-testene i [`e2e/`](e2e/) mocker tjek-endpointet
+og rammer alle tilstande af »Har jeg IPv6?«-widgetten i det rigtige bundle.

--- a/data/bolignet-aarhus.json
+++ b/data/bolignet-aarhus.json
@@ -4,6 +4,6 @@
   "url": "https://bolignet-aarhus.dk",
   "ipv6": false,
   "comment": "Vi tester IPv6 i backbone. Det tilbydes ikke til nogle kunder på nuværende tidspunkt. Vi har ingen umiddelbare planer for udrulning til private.\n ",
-  "partial": true,
+  "partial": false,
   "sources": [{ "date": "2017-04-21", "name": "ISP", "url": null }]
 }

--- a/data/telenor.json
+++ b/data/telenor.json
@@ -4,7 +4,7 @@
   "url": "https://www.telenor.dk",
   "ipv6": false,
   "comment": "Der er ikke specifikke planer for implementering af IPv6 i øjeblikket.",
-  "partial": true,
+  "partial": false,
   "sources": [
     {
       "date": "2023-04-20",

--- a/e2e/smoke.spec.js
+++ b/e2e/smoke.spec.js
@@ -1,0 +1,84 @@
+// End-to-end smoke tests against the production build (`gatsby serve`).
+// The IPv6 check endpoint is mocked per test, so every state of the
+// "Har jeg IPv6?" widget is exercised through the real bundle — fetch,
+// JSONP parsing, classification and rendering included.
+const { test, expect } = require('@playwright/test');
+
+const isCheckEndpoint = url => url.hostname === 'check.ipv6-adresse.dk';
+const jsonp = data => `updateIPData(${JSON.stringify(data)});`;
+
+const mockCheck = (page, data) =>
+  page.route(isCheckEndpoint, route =>
+    route.fulfill({ status: 200, contentType: 'text/javascript', body: jsonp(data) }));
+
+test('front page renders the stats, chart and ISP table', async ({ page }) => {
+  await mockCheck(page, { address: '2001:db8::1', isp_name: 'Example A/S', country: 'Denmark' });
+  await page.goto('/');
+
+  await expect(page.locator('h1')).toContainText('Vi er løbet tør for IPv4-adresser');
+  await expect(page.locator('.stats')).toContainText(/Internetudbydere på listen: \d+/);
+
+  // The adoption chart only renders with at least two adoption events
+  await expect(page.locator('figure svg[role="img"]')).toBeVisible();
+
+  // gridjs table: every ISP name links out with a safe http(s) href
+  const links = page.locator('a.ispLink');
+  await expect(links.first()).toBeVisible();
+  expect(await links.count()).toBeGreaterThan(30);
+  for (const href of await links.evaluateAll(as => as.map(a => a.href))) {
+    expect(href).toMatch(/^https?:\/\//);
+  }
+});
+
+test('table search narrows the list', async ({ page }) => {
+  await mockCheck(page, { address: '192.0.2.1', isp_name: 'Example A/S' });
+  await page.goto('/');
+
+  // gridjs renders after hydration — wait for rows before taking the baseline
+  const rows = page.locator('.gridjs tbody tr');
+  await expect(rows.first()).toBeVisible();
+  const all = await rows.count();
+  expect(all).toBeGreaterThan(30);
+
+  await page.getByPlaceholder('🔎 Søg i tabellen').fill('Fiberby');
+  await expect(rows.first()).toContainText('Fiberby');
+  expect(await rows.count()).toBeLessThan(all);
+});
+
+test('a visitor with IPv6 sees the success state and their details', async ({ page }) => {
+  await mockCheck(page, { address: '2001:db8::1', isp_name: 'Example A/S', country: 'Denmark' });
+  await page.goto('/');
+
+  const widget = page.locator('.DoIHaveIPv6');
+  await expect(widget).toContainText('Ja! Du har IPv6');
+  await expect(widget).toContainText('Din IPv6-adresse er 2001:db8::1');
+  await expect(widget).toContainText('Din udbyder er Example A/S');
+  await expect(widget).not.toContainText('Din IPv4-adresse');
+});
+
+test('a visitor without IPv6 sees the IPv4 state', async ({ page }) => {
+  await mockCheck(page, { address: '192.0.2.1', isp_name: 'Example A/S', country: 'Denmark' });
+  await page.goto('/');
+
+  const widget = page.locator('.DoIHaveIPv6');
+  await expect(widget).toContainText('Øv! Du har desværre ikke IPv6');
+  await expect(widget).toContainText('Din IPv4-adresse er 192.0.2.1');
+  await expect(widget).not.toContainText('Din IPv6-adresse');
+});
+
+test('an unreachable check endpoint degrades to the failure state', async ({ page }) => {
+  await page.route(isCheckEndpoint, route => route.abort());
+  await page.goto('/');
+
+  await expect(page.locator('.DoIHaveIPv6'))
+    .toContainText('Vi kunne desværre ikke teste om du har IPv6');
+});
+
+test('a non-JSONP answer (e.g. an error page) also degrades to the failure state', async ({ page }) => {
+  await page.route(isCheckEndpoint, route =>
+    route.fulfill({ status: 502, contentType: 'text/html', body: '<html>502 Bad Gateway</html>' }));
+  await page.goto('/');
+
+  await expect(page.locator('.DoIHaveIPv6'))
+    .toContainText('Vi kunne desværre ikke teste om du har IPv6');
+});

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -1,7 +1,7 @@
-const crypto = require('crypto');
 const fs = require('fs');
 const path = require('path');
 const { safeUrl } = require('./src/utils/safe');
+const { collectScriptHashes } = require('./src/utils/csp');
 
 // Favicons used to be loaded straight from Google's favicon endpoint, which
 // handed every visitor's IP and User-Agent to a third party 41 times per page
@@ -51,11 +51,7 @@ exports.onPostBuild = () => {
   for (const file of fs.readdirSync(pub, { recursive: true })) {
     // page-data/ contains a *directory* named 404.html — check it is a file
     if (!file.endsWith('.html') || !fs.statSync(path.join(pub, file)).isFile()) continue;
-    const html = fs.readFileSync(path.join(pub, file), 'utf8');
-    for (const [, attrs, body] of html.matchAll(/<script\b([^>]*)>([\s\S]*?)<\/script>/g)) {
-      if (/\bsrc\s*=/.test(attrs) || body === '') continue;
-      scriptHashes.add(`'sha256-${crypto.createHash('sha256').update(body).digest('base64')}'`);
-    }
+    collectScriptHashes(fs.readFileSync(path.join(pub, file), 'utf8'), scriptHashes);
   }
 
   const csp = [

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,8 +22,11 @@
         "react-dom": "^18.3.1",
         "sass": "^1.83.0"
       },
+      "devDependencies": {
+        "@playwright/test": "^1.62.1"
+      },
       "engines": {
-        "node": ">=20"
+        "node": ">=20.19.0"
       }
     },
     "node_modules/@ardatan/relay-compiler": {
@@ -2783,9 +2786,6 @@
       "cpu": [
         "arm"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2801,9 +2801,6 @@
       "integrity": "sha512-dqVSFynCox4C/J8kT16V7SIFAns0IjgLwkvYT7p8LQVmJ5OS5b6tI9IGflxTeuBS//zXeFIUbwt5dwxyZ17cnA==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -2821,9 +2818,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2839,9 +2833,6 @@
       "integrity": "sha512-bsb4rI+NldGOsXuej2r8OdSS8+zXDVaCWxyWrcv6kneTOlgAHtZABRzBBCwdsPiD90J4myNJuHpg6kA20ImW/w==",
       "cpu": [
         "riscv64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -2859,9 +2850,6 @@
       "cpu": [
         "s390x"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2877,9 +2865,6 @@
       "integrity": "sha512-ITPEtgffGJ0S6G9dRyw/366tJQqFRcHWPHhC+Stpg3Z8AEMrDrTr2lhdz4f/Y/HMbRh//7Z5mBzEpVdi62Oc3w==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -2897,9 +2882,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2916,9 +2898,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2934,9 +2913,6 @@
       "integrity": "sha512-affVWCTLooy8TSxbDx2qkzuDeaWLNVBA+P//FNBirHsXpP2fuBhk5AuboYUnrDnzoXes8GFjpTx0SBFOCRg+FA==",
       "cpu": [
         "arm"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -2960,9 +2936,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2984,9 +2957,6 @@
       "integrity": "sha512-sMd8rDxmpLOwv/7N44klFjOD5DUO7FLdjiXDI0hoxYaf7Ar262dQIEkosE98bps+5HPLtp/EvNqeqQtOycP/IA==",
       "cpu": [
         "ppc64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -3010,9 +2980,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3034,9 +3001,6 @@
       "integrity": "sha512-KgAxQ0DxpNOq1rG2t5cgTgShJFGSuU7XO45cqC+1NVOuZnP6tlgZRuSYOfNupGkHID0o3cJOsw4DVeJpMovcGw==",
       "cpu": [
         "s390x"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -3060,9 +3024,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3085,9 +3046,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3109,9 +3067,6 @@
       "integrity": "sha512-6O1NPKcDVj9QEdg7Hx549EX8U0rp6yXQERqru6yRN7fGBn32UvIRJUlWnk+8xDCiG76hXVBbX82NZ/ZKr0euIg==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -4320,9 +4275,6 @@
       "cpu": [
         "arm"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4342,9 +4294,6 @@
       "integrity": "sha512-9c6AUHgHoG+IY88MRIHupztQiQnrbqHYQjkM2btA+Bf/wQnQMuiD0Wfk1EVv3TlNT3x41uU71rn6E4xh/+zvkw==",
       "cpu": [
         "arm"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -4366,9 +4315,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4388,9 +4334,6 @@
       "integrity": "sha512-WhB2e/V7rqdHHWZusBSPuy5Ei8S6lSz6FE5TKKQz5h3a0O+C+mhY7vxU9b/stqvMb8beLnPY82ZrFTLKs+SrKA==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -4412,9 +4355,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4434,9 +4374,6 @@
       "integrity": "sha512-tkBYKt7YQrjIJWYDnto2YgO8MRkjlMTSNoRHzsXinBqbLdeOM3L32wPZJvIZxqaLMfSlS/4sUjH/6STVP/XDLw==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -4522,6 +4459,22 @@
       },
       "peerDependencies": {
         "@parcel/core": "^2.8.3"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.62.1.tgz",
+      "integrity": "sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@pmmmwh/react-refresh-webpack-plugin": {
@@ -14614,6 +14567,53 @@
       "resolved": "https://registry.npmjs.org/platform/-/platform-1.3.6.tgz",
       "integrity": "sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg==",
       "license": "MIT"
+    },
+    "node_modules/playwright": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.1.tgz",
+      "integrity": "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.1.tgz",
+      "integrity": "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
     },
     "node_modules/possible-typed-array-names": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "build": "gatsby build",
     "serve": "gatsby serve",
     "clean": "gatsby clean",
-    "test": "node --test test/*.test.js"
+    "test": "node --test --experimental-test-coverage test/*.test.js",
+    "test:e2e": "playwright test"
   },
   "dependencies": {
     "gatsby": "^5.16.1",
@@ -45,5 +46,8 @@
     "xml2js": "^0.6.2",
     "path-to-regexp@<0.1.13": "0.1.13",
     "tmp@<0.2.6": "^0.2.6"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.62.1"
   }
 }

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,0 +1,24 @@
+const { defineConfig } = require('@playwright/test');
+
+// Smoke tests against the real production build: run `npm run build` first,
+// then `npm run test:e2e` — the config serves public/ via `gatsby serve`.
+// Environments with a pre-installed browser can skip `playwright install`
+// by pointing CHROMIUM_PATH at the executable.
+module.exports = defineConfig({
+  testDir: './e2e',
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 1 : 0,
+  reporter: process.env.CI ? 'list' : [['list'], ['html', { open: 'never' }]],
+  use: {
+    baseURL: 'http://localhost:9000',
+    launchOptions: process.env.CHROMIUM_PATH
+      ? { executablePath: process.env.CHROMIUM_PATH }
+      : {},
+  },
+  webServer: {
+    command: 'npm run serve',
+    url: 'http://localhost:9000',
+    reuseExistingServer: !process.env.CI,
+    timeout: 60_000,
+  },
+});

--- a/src/components/AdoptionChart/component.js
+++ b/src/components/AdoptionChart/component.js
@@ -1,5 +1,6 @@
 import * as React from 'react';
-import { safeDate, formatDate } from '../../utils/safe';
+import { formatDate } from '../../utils/safe';
+import { adoptionEvents } from '../../utils/adoption';
 
 // Chart tokens — line color validated >= 3:1 on white; site accent used only as fill
 const tokens = {
@@ -10,17 +11,6 @@ const tokens = {
   muted: '#898781',
   ink: '#333',
 };
-
-// Earliest valid source date per ISP with (full or partial) IPv6 support
-const adoptionEvents = ispData => ispData
-  .filter(isp => isp.ipv6 === true && isp.sources && isp.sources.length > 0)
-  .map(isp => {
-    const dates = isp.sources.map(s => safeDate(s.date)).filter(Boolean);
-    return dates.length ? { name: isp.name, date: new Date(Math.min(...dates)) } : null;
-  })
-  .filter(Boolean)
-  .sort((a, b) => a.date - b.date)
-  .map((e, i) => ({ ...e, count: i + 1 }));
 
 const AdoptionChart = ({ ispData }) => {
   const [hover, setHover] = React.useState(null);

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -10,18 +10,13 @@ import '../styles/index.style.scss';
 
 import AdoptionChart from '../components/AdoptionChart/component';
 import { safeUrl, safeDate, formatDate } from '../utils/safe';
+import { ispState, compareState, comparePrefix, newestDate, ispStats } from '../utils/isp';
 
 // gridjs addresses cells by position, so the hidden columns the visible
 // formatters read from are declared once here and looked up by name. Reordering
 // or adding a column can no longer feed the wrong field into an href.
 const HIDDEN_COLUMNS = ['color', 'url'];
 const hidden = name => HIDDEN_COLUMNS.indexOf(name);
-
-// Newest valid date across an ISP's sources, regardless of array order
-const newestDate = sources => sources.reduce((max, s) => {
-  const d = safeDate(s.date);
-  return d && (!max || d > max) ? d : max;
-}, null);
 
 export const query = graphql`
   query GetISPData {
@@ -48,16 +43,9 @@ export const query = graphql`
 `
 
 const IndexPage = ({ data }) => {
-  const ispData = data.allDataJson.edges.map(x => ({
-    ...x.node,
-    color: !x.node.ipv6 ? '#ef9a9a' : (x.node.partial) ? '#ffe082' : '#a5d6a7',
-    state: !x.node.ipv6 ? 'Nej' : (x.node.partial) ? 'Delvist' : 'Ja',
-  }));
+  const ispData = data.allDataJson.edges.map(x => ({ ...x.node, ...ispState(x.node) }));
 
-  const total = ispData.length;
-  const full = ispData.filter(x => x.ipv6 && !x.partial).length;
-  const partial = ispData.filter(x => x.ipv6 && x.partial).length;
-  const none = total - full - partial;
+  const { total, full, partial, none } = ispStats(ispData);
   const pct = n => (n / total * 100).toFixed(0);
 
   return (
@@ -153,10 +141,7 @@ const IndexPage = ({ data }) => {
                 },
                 sort: {
                   enabled: true,
-                  compare: (a, b) => {
-                    const priority = { "Ja": 0, "Delvist": 1, "Nej": 2 };
-                    return priority[a] - priority[b];
-                  }
+                  compare: compareState
                 }
               },
               {
@@ -174,11 +159,7 @@ const IndexPage = ({ data }) => {
                 },
                 sort: {
                   enabled: true,
-                  compare: (a, b) => {
-                    // Treat a missing prefix as the largest, so it sorts last
-                    const parsePrefix = p => (p ? parseInt(p.replace('/', ''), 10) : 128);
-                    return parsePrefix(a) - parsePrefix(b);
-                  }
+                  compare: comparePrefix
                 }
               },
 

--- a/src/services/checkipv6status.js
+++ b/src/services/checkipv6status.js
@@ -1,4 +1,5 @@
 import { parseJsonp } from '../utils/safe';
+import { classifyAddress } from '../utils/ipcheck';
 
 const addrInfoUrl =
   process.env.GATSBY_ADDRINFO_URL || 'https://check.ipv6-adresse.dk';
@@ -6,16 +7,7 @@ const addrInfoUrl =
 const check = () =>
   fetch(addrInfoUrl, { signal: AbortSignal.timeout(10000) })
     .then(res => res.text())
-    .then(text => {
-      const data = parseJsonp(text);
-      const isIPv6 = data.address.includes(':'); // an IPv4 address never contains a colon
-
-      return {
-        ispName: data.isp_name,
-        ipv6Address: isIPv6 ? data.address : null,
-        ipv4Address: isIPv6 ? null : data.address,
-      };
-    })
+    .then(text => classifyAddress(parseJsonp(text)))
     .catch(() => ({ failed: true }));
 
 // Started at import time so the request is already in flight before React

--- a/src/utils/adoption.js
+++ b/src/utils/adoption.js
@@ -1,0 +1,19 @@
+// CommonJS so `node --test` can load it without a transpile step;
+// webpack's CJS interop handles the named imports in src/.
+const { safeDate } = require('./safe');
+
+// Earliest valid source date per ISP with (full or partial) IPv6 support,
+// sorted chronologically and numbered cumulatively — the chart's step data.
+// ISPs without any parseable source date are left out rather than plotted
+// at an arbitrary position.
+const adoptionEvents = ispData => ispData
+  .filter(isp => isp.ipv6 === true && isp.sources && isp.sources.length > 0)
+  .map(isp => {
+    const dates = isp.sources.map(s => safeDate(s.date)).filter(Boolean);
+    return dates.length ? { name: isp.name, date: new Date(Math.min(...dates)) } : null;
+  })
+  .filter(Boolean)
+  .sort((a, b) => a.date - b.date)
+  .map((e, i) => ({ ...e, count: i + 1 }));
+
+module.exports = { adoptionEvents };

--- a/src/utils/csp.js
+++ b/src/utils/csp.js
@@ -1,0 +1,15 @@
+// CommonJS — shared between gatsby-node.js and the tests.
+const crypto = require('crypto');
+
+// CSP hashes for every inline <script> body in a page. Scripts loaded via
+// src= are already covered by 'self', and an empty body has nothing to hash.
+// Adds to (and returns) `hashes` so callers can accumulate across pages.
+const collectScriptHashes = (html, hashes = new Set()) => {
+  for (const [, attrs, body] of html.matchAll(/<script\b([^>]*)>([\s\S]*?)<\/script>/g)) {
+    if (/\bsrc\s*=/.test(attrs) || body === '') continue;
+    hashes.add(`'sha256-${crypto.createHash('sha256').update(body).digest('base64')}'`);
+  }
+  return hashes;
+};
+
+module.exports = { collectScriptHashes };

--- a/src/utils/ipcheck.js
+++ b/src/utils/ipcheck.js
@@ -1,0 +1,16 @@
+// CommonJS so `node --test` can load it without a transpile step;
+// webpack's CJS interop handles the named imports in src/.
+
+// Shapes the parsed payload from the check endpoint into what the widget
+// renders. An IPv4 address never contains a colon. Throws on a payload
+// without an address — the caller turns that into { failed: true }.
+const classifyAddress = data => {
+  const isIPv6 = data.address.includes(':');
+  return {
+    ispName: data.isp_name,
+    ipv6Address: isIPv6 ? data.address : null,
+    ipv4Address: isIPv6 ? null : data.address,
+  };
+};
+
+module.exports = { classifyAddress };

--- a/src/utils/isp.js
+++ b/src/utils/isp.js
@@ -1,0 +1,38 @@
+// CommonJS so `node --test` can load it without a transpile step;
+// webpack's CJS interop handles the named imports in src/.
+const { safeDate } = require('./safe');
+
+// Presentation state per ISP. `partial` only counts when ipv6 is true, so a
+// stale partial flag on an ISP without IPv6 cannot upgrade it to "Delvist".
+const ispState = ({ ipv6, partial }) =>
+  !ipv6
+    ? { state: 'Nej', color: '#ef9a9a' }
+    : partial
+      ? { state: 'Delvist', color: '#ffe082' }
+      : { state: 'Ja', color: '#a5d6a7' };
+
+// Table sort order for the labels ispState produces. Kept next to ispState so
+// a renamed label cannot silently fall out of the priority map.
+const STATE_PRIORITY = { 'Ja': 0, 'Delvist': 1, 'Nej': 2 };
+const compareState = (a, b) => STATE_PRIORITY[a] - STATE_PRIORITY[b];
+
+// Treat a missing prefix as the largest, so it sorts last
+const parsePrefix = p => (p ? parseInt(p.replace('/', ''), 10) : 128);
+const comparePrefix = (a, b) => parsePrefix(a) - parsePrefix(b);
+
+// Newest valid date across an ISP's sources, regardless of array order
+const newestDate = sources => sources.reduce((max, s) => {
+  const d = safeDate(s.date);
+  return d && (!max || d > max) ? d : max;
+}, null);
+
+// The headline numbers above the table. partial only counts alongside ipv6,
+// mirroring ispState.
+const ispStats = ispData => {
+  const total = ispData.length;
+  const full = ispData.filter(x => x.ipv6 && !x.partial).length;
+  const partial = ispData.filter(x => x.ipv6 && x.partial).length;
+  return { total, full, partial, none: total - full - partial };
+};
+
+module.exports = { ispState, compareState, comparePrefix, newestDate, ispStats };

--- a/test/adoption.test.js
+++ b/test/adoption.test.js
@@ -1,0 +1,46 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { adoptionEvents } = require('../src/utils/adoption');
+
+const isp = (name, ipv6, sources) => ({ name, ipv6, sources });
+const src = date => ({ name: 'Kilde', url: null, date });
+
+test('only ISPs with ipv6 and at least one source make the chart', () => {
+  const events = adoptionEvents([
+    isp('A', true, [src('2020-01-01')]),
+    isp('No IPv6', false, [src('2019-01-01')]),
+    isp('No sources', true, []),
+    isp('Sources missing', true, undefined),
+  ]);
+  assert.deepEqual(events.map(e => e.name), ['A']);
+});
+
+test('the earliest source date wins, regardless of array order', () => {
+  const [e] = adoptionEvents([
+    isp('A', true, [src('2021-06-01'), src('2018-03-15'), src('2020-01-01')]),
+  ]);
+  assert.equal(e.date.toISOString().slice(0, 10), '2018-03-15');
+});
+
+test('invalid dates are skipped; an ISP with only invalid dates is dropped', () => {
+  const events = adoptionEvents([
+    isp('Mixed', true, [src('not-a-date'), src('2020-05-05')]),
+    isp('All bad', true, [src('nope'), src('')]),
+  ]);
+  assert.deepEqual(events.map(e => e.name), ['Mixed']);
+  assert.equal(events[0].date.toISOString().slice(0, 10), '2020-05-05');
+});
+
+test('events are sorted chronologically and counted cumulatively', () => {
+  const events = adoptionEvents([
+    isp('Late', true, [src('2022-01-01')]),
+    isp('Early', true, [src('2015-01-01')]),
+    isp('Middle', true, [src('2018-01-01')]),
+  ]);
+  assert.deepEqual(events.map(e => e.name), ['Early', 'Middle', 'Late']);
+  assert.deepEqual(events.map(e => e.count), [1, 2, 3]);
+});
+
+test('empty input yields an empty chart, not a crash', () => {
+  assert.deepEqual(adoptionEvents([]), []);
+});

--- a/test/csp.test.js
+++ b/test/csp.test.js
@@ -1,0 +1,45 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const crypto = require('crypto');
+const { collectScriptHashes } = require('../src/utils/csp');
+
+const sha256 = body =>
+  `'sha256-${crypto.createHash('sha256').update(body).digest('base64')}'`;
+
+test('hashes every inline script body, including multiline ones', () => {
+  const html = `<html><body>
+    <script>window.a=1</script>
+    <script type="application/json" id="x">{
+      "multi": "line"
+    }</script>
+  </body></html>`;
+  const hashes = collectScriptHashes(html);
+  assert.equal(hashes.size, 2);
+  assert.ok(hashes.has(sha256('window.a=1')));
+  assert.ok(hashes.has(sha256('{\n      "multi": "line"\n    }')));
+});
+
+// External scripts are covered by 'self' in the CSP; hashing them would be
+// wrong, and hashing the empty string would whitelist every empty script.
+test('skips src= scripts and empty bodies', () => {
+  const html = [
+    '<script src="/app.js"></script>',
+    "<script async src='/x.js'></script>",
+    '<script></script>',
+  ].join('\n');
+  assert.equal(collectScriptHashes(html).size, 0);
+});
+
+test('identical bodies across pages collapse to one hash', () => {
+  const hashes = new Set();
+  collectScriptHashes('<script>shared()</script>', hashes);
+  collectScriptHashes('<script>shared()</script><script>other()</script>', hashes);
+  assert.equal(hashes.size, 2);
+});
+
+// The header value wraps each hash in single quotes — a regression here
+// produces a syntactically invalid CSP that browsers ignore entirely.
+test('hashes are emitted in CSP source-list form', () => {
+  const [hash] = [...collectScriptHashes('<script>x()</script>')];
+  assert.match(hash, /^'sha256-[A-Za-z0-9+/]+={0,2}'$/);
+});

--- a/test/data.test.js
+++ b/test/data.test.js
@@ -1,0 +1,74 @@
+// Semantic checks on data/*.json that the JSON schema cannot express.
+// CI already validates shape with ajv; this guards meaning.
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const path = require('path');
+const { safeUrl, safeDate } = require('../src/utils/safe');
+
+const dataDir = path.join(__dirname, '..', 'data');
+const isps = fs.readdirSync(dataDir)
+  .filter(f => f.endsWith('.json'))
+  .map(f => ({ file: f, ...JSON.parse(fs.readFileSync(path.join(dataDir, f), 'utf8')) }));
+
+test('the data directory is populated', () => {
+  assert.ok(isps.length >= 40, `only found ${isps.length} data files`);
+});
+
+test('every ISP url is a valid http(s) URL', () => {
+  for (const isp of isps) {
+    assert.ok(safeUrl(isp.url), `${isp.file}: unparseable url ${isp.url}`);
+  }
+});
+
+test('source urls are valid http(s) URLs when present', () => {
+  for (const isp of isps) {
+    for (const s of isp.sources || []) {
+      if (s.url != null) {
+        assert.ok(safeUrl(s.url), `${isp.file}: unparseable source url ${s.url}`);
+      }
+    }
+  }
+});
+
+// The schema's date pattern accepts 2026-13-99; this does not.
+test('source dates are real dates and not in the future', () => {
+  const now = new Date();
+  for (const isp of isps) {
+    for (const s of isp.sources || []) {
+      const d = safeDate(s.date);
+      assert.ok(d, `${isp.file}: invalid date ${s.date}`);
+      assert.ok(d <= now, `${isp.file}: source dated in the future: ${s.date}`);
+    }
+  }
+});
+
+test('ISP names are unique', () => {
+  const seen = new Map();
+  for (const isp of isps) {
+    const key = isp.name.toLowerCase();
+    assert.ok(!seen.has(key), `${isp.file}: duplicate name "${isp.name}" (also in ${seen.get(key)})`);
+    seen.set(key, isp.file);
+  }
+});
+
+// Two files pointing at one hostname would fight over the same favicon and
+// probably means an ISP was added twice under different names.
+test('ISP url hostnames are unique', () => {
+  const seen = new Map();
+  for (const isp of isps) {
+    const host = safeUrl(isp.url).hostname;
+    assert.ok(!seen.has(host), `${isp.file}: duplicate hostname ${host} (also in ${seen.get(host)})`);
+    seen.set(host, isp.file);
+  }
+});
+
+// partial means "IPv6, but only for some customers" — it is meaningless
+// without ipv6, and the site ignores it in that case. Keep the data honest.
+test('partial implies ipv6', () => {
+  for (const isp of isps) {
+    if (isp.partial) {
+      assert.ok(isp.ipv6, `${isp.file}: partial is true but ipv6 is false`);
+    }
+  }
+});

--- a/test/ipcheck.test.js
+++ b/test/ipcheck.test.js
@@ -1,0 +1,33 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { classifyAddress } = require('../src/utils/ipcheck');
+
+test('a colon means IPv6, and the IPv4 slot stays empty', () => {
+  const r = classifyAddress({ address: '2001:db8::1', isp_name: 'Example A/S' });
+  assert.deepEqual(r, {
+    ispName: 'Example A/S',
+    ipv6Address: '2001:db8::1',
+    ipv4Address: null,
+  });
+});
+
+test('no colon means IPv4, and the IPv6 slot stays empty', () => {
+  const r = classifyAddress({ address: '192.0.2.1', isp_name: 'Example A/S' });
+  assert.deepEqual(r, {
+    ispName: 'Example A/S',
+    ipv6Address: null,
+    ipv4Address: '192.0.2.1',
+  });
+});
+
+// The endpoint has no documented schema. If it ever answers without an
+// address, the service's .catch must kick in — so this has to throw, not
+// classify garbage.
+test('a payload without an address throws', () => {
+  assert.throws(() => classifyAddress({}));
+  assert.throws(() => classifyAddress({ isp_name: 'Example A/S' }));
+});
+
+test('a missing isp_name is passed through as undefined, not invented', () => {
+  assert.equal(classifyAddress({ address: '192.0.2.1' }).ispName, undefined);
+});

--- a/test/isp.test.js
+++ b/test/isp.test.js
@@ -1,0 +1,76 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const {
+  ispState, compareState, comparePrefix, newestDate, ispStats,
+} = require('../src/utils/isp');
+
+test('ispState maps the ipv6/partial flags to label and color', () => {
+  assert.deepEqual(ispState({ ipv6: true, partial: false }), { state: 'Ja', color: '#a5d6a7' });
+  assert.deepEqual(ispState({ ipv6: true, partial: true }), { state: 'Delvist', color: '#ffe082' });
+  assert.deepEqual(ispState({ ipv6: false, partial: false }), { state: 'Nej', color: '#ef9a9a' });
+});
+
+// A stale partial flag must not upgrade an ISP without IPv6
+test('ispState ignores partial when ipv6 is false', () => {
+  assert.equal(ispState({ ipv6: false, partial: true }).state, 'Nej');
+});
+
+test('compareState orders Ja before Delvist before Nej', () => {
+  assert.deepEqual(
+    ['Nej', 'Ja', 'Delvist'].sort(compareState),
+    ['Ja', 'Delvist', 'Nej']
+  );
+});
+
+// compareState only knows the labels ispState produces. This pins the
+// coupling: if a label is renamed in one place but not the other, sorting
+// silently degrades to NaN comparisons.
+test('compareState covers exactly the labels ispState can produce', () => {
+  for (const flags of [
+    { ipv6: true, partial: false },
+    { ipv6: true, partial: true },
+    { ipv6: false, partial: false },
+  ]) {
+    const { state } = ispState(flags);
+    assert.ok(Number.isFinite(compareState(state, 'Ja')), `no sort priority for "${state}"`);
+  }
+});
+
+// null, not undefined: sort() skips the comparator entirely for undefined
+// elements, and null is what gridjs hands over for a missing cell.
+test('comparePrefix sorts numerically and puts missing prefixes last', () => {
+  assert.deepEqual(
+    ['/56', null, '/48', '/64'].sort(comparePrefix),
+    ['/48', '/56', '/64', null]
+  );
+  assert.ok(comparePrefix('/128', null) <= 0, 'missing sorts with the largest real prefix');
+});
+
+test('newestDate picks the newest valid date regardless of order', () => {
+  const d = newestDate([
+    { date: '2018-06-17' },
+    { date: '2021-08-09' },
+    { date: '2017-06-06' },
+  ]);
+  assert.equal(d.toISOString().slice(0, 10), '2021-08-09');
+});
+
+test('newestDate skips invalid dates and returns null when none are valid', () => {
+  assert.equal(
+    newestDate([{ date: 'nope' }, { date: '2020-01-01' }]).toISOString().slice(0, 10),
+    '2020-01-01'
+  );
+  assert.equal(newestDate([{ date: 'nope' }]), null);
+  assert.equal(newestDate([]), null);
+});
+
+test('ispStats splits the list into full/partial/none and they add up', () => {
+  const stats = ispStats([
+    { ipv6: true, partial: false },
+    { ipv6: true, partial: false },
+    { ipv6: true, partial: true },
+    { ipv6: false, partial: false },
+    { ipv6: false, partial: true }, // stale flag — counts as none
+  ]);
+  assert.deepEqual(stats, { total: 5, full: 2, partial: 1, none: 2 });
+});


### PR DESCRIPTION
## Summary

Unit tests previously covered only `src/utils/safe.js` — the rest of the site's decision-making logic lived inline in ESM/JSX files that `node --test` cannot load, so it was effectively untestable. This PR follows the pattern `safe.js` established: pull that logic into small CommonJS utility modules, test each one, and leave the components as thin rendering shells. It also adds semantic data-quality tests and Playwright smoke tests against the production build.

## Extracted modules (each with a matching test file)

| Module | Extracted from | Contains |
|---|---|---|
| `src/utils/ipcheck.js` | `services/checkipv6status.js` | `classifyAddress` — IPv6/IPv4 split of the check endpoint's payload |
| `src/utils/adoption.js` | `AdoptionChart` | `adoptionEvents` — earliest-source-per-ISP step data for the chart |
| `src/utils/isp.js` | `pages/index.js` | `ispState`, `compareState`, `comparePrefix`, `newestDate`, `ispStats` |
| `src/utils/csp.js` | `gatsby-node.js` | `collectScriptHashes` — inline-script hashing that feeds the CSP header |

`npm test` now runs 35 tests (up from 7) and reports coverage via `--experimental-test-coverage` — 100% lines/functions on all util modules.

## Data-quality tests (`test/data.test.js`)

Guards what `schema.json` cannot express: dates must be real and not in the future (the schema's pattern accepts `2026-13-99`), ISP/source URLs must parse as http(s), names and hostnames must be unique across files, and `partial: true` requires `ipv6: true`.

That last invariant surfaced two stale flags: `bolignet-aarhus.json` and `telenor.json` carried `partial: true` alongside `ipv6: false`, while their comments state no customers get IPv6. Corrected to `partial: false` — rendering is unchanged, since the site already ignores `partial` when `ipv6` is false.

## End-to-end smoke tests (`e2e/`, Playwright)

Run against the real production build served by `gatsby serve` (`npm run build && npm run test:e2e`). The check endpoint is mocked per test, so every state of the "Har jeg IPv6?" widget — IPv6, IPv4-only, unreachable endpoint, non-JSONP error page — is exercised through the actual bundle: fetch, JSONP parsing, classification and rendering. Also covers the stats block, the adoption chart, table rendering with safe hrefs, and table search. CI runs them after the existing build + sanity-check steps.

## Verification

- `npm test`: 35/35 pass, 100% line coverage on `src/utils/*`
- `npx ajv-cli validate`: all 41 data files still valid after the two data fixes
- `npm run build`: succeeds with the refactored components; `public/_headers` still contains the CSP hashes
- `npm run test:e2e`: 6/6 pass against the build

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016pkdSrzyfikntTsL2UkZDk

---
_Generated by [Claude Code](https://claude.ai/code/session_016pkdSrzyfikntTsL2UkZDk)_