### PR TITLE
Update ISP data from reader mail triage

### DIFF
--- a/data/andels.net.json
+++ b/data/andels.net.json
@@ -5,5 +5,16 @@
   "ipv6": false,
   "comment": "Vi har ikke nogen planer om at levere det, da der er for få hjemmesider der understøtter det i dag.",
   "partial": false,
-  "sources": [{ "date": "2020-09-21", "name": "ISP", "url": null }]
+  "sources": [
+    {
+      "date": "2022-11-21",
+      "name": "ISP (Email)",
+      "url": null
+    },
+    {
+      "date": "2020-09-21",
+      "name": "ISP",
+      "url": null
+    }
+  ]
 }

--- a/data/eesy.json
+++ b/data/eesy.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "./../schema.json",
+  "name": "eesy",
+  "url": "https://www.eesy.dk",
+  "ipv6": true,
+  "comment": "eesy kører på TDC NET's mobilnet, hvor der leveres dual-stack IPv4/IPv6 på mobildata.",
+  "partial": false,
+  "sources": [
+    { "date": "2025-12-09", "name": "Brugerrapport (Email)", "url": null },
+    { "date": "2025-09-09", "name": "Brugerrapport (Email)", "url": null }
+  ]
+}

--- a/data/fastspeed.json
+++ b/data/fastspeed.json
@@ -3,8 +3,19 @@
   "name": "Fastspeed",
   "url": "https://fastspeed.dk",
   "ipv6": true,
-  "assignedprefix": "/48",
+  "assignedprefix": "/60",
   "comment": "Fastspeed understøtter IPv6. IPv6 på COAX forbindelser understøttes ikke af TDC.",
   "partial": true,
-  "sources": [{ "date": "2024-05-01", "name": "ISP", "url": "https://fastspeed.dk/kundeservice/router-opsaetning-indstilling/ip-adresser/" }]
+  "sources": [
+    {
+      "date": "2026-05-28",
+      "name": "Brugerrapport (Email)",
+      "url": null
+    },
+    {
+      "date": "2024-05-01",
+      "name": "ISP",
+      "url": "https://fastspeed.dk/kundeservice/router-opsaetning-indstilling/ip-adresser/"
+    }
+  ]
 }

--- a/data/fiberby.json
+++ b/data/fiberby.json
@@ -3,7 +3,18 @@
   "name": "Fiberby",
   "url": "https://fiberby.dk",
   "ipv6": true,
-  "comment": "Vi tilbyder statiske IPv6 til erhvervskunder og privatkunder ved forespørgsel; For privat kunder forudsættes samtidig statisk offentlig IPv4-adresse.",
-  "partial": false,
-  "sources": [{ "date": "2020-04-24", "name": "ISP", "url": null }]
+  "comment": "Vi tilbyder statiske IPv6 til erhvervskunder og privatkunder ved forespørgsel; For privat kunder forudsættes samtidig statisk offentlig IPv4-adresse (100 kr i oprettelse + 25 kr/md). IPv6 leveres altså ikke som standard til private.",
+  "partial": true,
+  "sources": [
+    {
+      "date": "2026-08-16",
+      "name": "ISP (FAQ)",
+      "url": "https://fiberby.dk/faq/kan-jeg-faa-en-fast-ip/"
+    },
+    {
+      "date": "2020-04-24",
+      "name": "ISP",
+      "url": null
+    }
+  ]
 }

--- a/data/hiper.json
+++ b/data/hiper.json
@@ -3,14 +3,19 @@
   "name": "Hiper",
   "url": "https://www.hiper.dk",
   "ipv6": true,
-  "assignedprefix": "/48",
-  "comment": "Hiper understøtter IPv6. IPv6 på COAX forbindelser understøttes ikke af TDC.",
+  "assignedprefix": "/48 eller /56",
+  "comment": "Hiper leverer automatisk IPv6 via DHCPv6 på fibernet med fast /48 eller /56 prefix (fast /128 WAN). IPv6 på internet via kabel-tv (COAX) understøttes ikke.",
   "partial": true,
   "sources": [
     {
-      "date": "2021-06-21",
-      "name": "Tweet",
-      "url": "https://x.com/Nuudaydk/status/1406976008301973511"
+      "date": "2026-08-16",
+      "name": "ISP",
+      "url": "https://www.hiper.dk/hjaelp/udstyr/ip-adresse"
+    },
+    {
+      "date": "2018-12-08",
+      "name": "Blog (martinschultz.dev)",
+      "url": "https://www.martinschultz.dev/posts/2018-12-08-egen-router-hos-hiper/"
     }
   ]
 }

--- a/data/telmore.json
+++ b/data/telmore.json
@@ -2,8 +2,19 @@
   "$schema": "./../schema.json",
   "name": "Telmore",
   "url": "https://www.telmore.dk",
-  "ipv6": true,
-  "comment": "Du har både en IPv4 og en IPv6-adresse, i tilfælde af, at du kommer i kontakt med netværksudstyr, der bruger en IPv6-adresse",
+  "ipv6": false,
+  "comment": "Telmore understøtter ikke IPv6 på mobilnettet (bekræftet af Telmore kundeservice, marts 2025). Tweetet fra 2019 er ikke længere gældende.",
   "partial": false,
-  "sources": [{ "date": "2019-06-27", "name": "Tweet", "url": "https://x.com/telmore/status/1144160756075831297" }]
+  "sources": [
+    {
+      "date": "2025-03-30",
+      "name": "ISP (Email)",
+      "url": null
+    },
+    {
+      "date": "2019-06-27",
+      "name": "Tweet",
+      "url": "https://x.com/telmore/status/1144160756075831297"
+    }
+  ]
 }


### PR DESCRIPTION
Data fixes from a triage of reader mails to ipv6@ipv6-adresse.dk:

- **Fastspeed**: assigned prefix corrected /48 → /60 (user report, May 2026; confirmed by own connection)
- **Telmore**: `ipv6: false` — Telmore support confirmed no IPv6 on mobile (March 2025); the 2019 tweet source is outdated
- **Hiper**: replaced deleted tweet source with Hiper's own help page (auto IPv6 via DHCPv6 on fiber, fixed /48 or /56 prefix, no COAX) + martinschultz.dev guide
- **Fiberby**: `partial: true` — IPv6 for private customers only on request and requires paid static IPv4 (100 kr setup + 25 kr/md per Fiberby FAQ)
- **Andels.net**: added 2022 email source confirming still no IPv6 plans
- **eesy**: new entry — dual-stack IPv4/IPv6 on TDC NET mobile network (two user reports, 2025)

All tests pass (36 pass, 0 fail) incl. data schema validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)