### PR TITLE
Fix five dead source links found by a full link audit

### DIFF
--- a/data/bornfiber.json
+++ b/data/bornfiber.json
@@ -10,7 +10,7 @@
     {
       "date": "2015-11-26",
       "name": "Tweet",
-      "url": "https://x.com/BornFiber/status/669818778356699137"
+      "url": null
     }
   ]
 }

--- a/data/forskningsnettet.json
+++ b/data/forskningsnettet.json
@@ -9,7 +9,7 @@
     {
       "date": "2017-02-06",
       "name": "ISP",
-      "url": "https://www.deic.dk/da/IPv6"
+      "url": "https://web.archive.org/web/20210813033507/https://deic.dk/da/IPv6"
     }
   ]
 }

--- a/data/glentevejs-antennelaug.json
+++ b/data/glentevejs-antennelaug.json
@@ -9,7 +9,7 @@
     {
       "date": "2019-02-07",
       "name": "Referat af repræsentantskabsmøde",
-      "url": "https://www.glenten.dk/filarkiv/Bestyrelse/Referater/Reprasentantskab/Referat_reprasentantskabsmode_20190207_Glenten_FINAL.pdf"
+      "url": "https://web.archive.org/web/20250330215003/https://www.glenten.dk/filarkiv/Bestyrelse/Referater/Reprasentantskab/Referat_reprasentantskabsmode_20190207_Glenten_FINAL.pdf"
     }
   ]
 }

--- a/data/nef-fonden.json
+++ b/data/nef-fonden.json
@@ -6,7 +6,7 @@
   "comment": "NEF Fonden udruller større tekniske ændringer i deres fibernet fra april 2023. Men har endnu ikke en dato for, hvornår IPv6 kommer. Læs mere under \"Kilde\".",
   "partial": false,
   "sources": [
-    { "date": "2023-04-15", "name": "Læs mere (ISP)", "url": "https://nef.dk/kundeservice/fibernet-aendringer-2023/" },
+    { "date": "2023-04-15", "name": "Læs mere (ISP)", "url": "https://web.archive.org/web/20231021195732/https://nef.dk/kundeservice/fibernet-aendringer-2023/" },
     { "date": "2022-05-23", "name": "ISP", "url": null }
   ]
 }

--- a/data/telenor.json
+++ b/data/telenor.json
@@ -9,7 +9,7 @@
     {
       "date": "2023-04-20",
       "name": "FB Tråd",
-      "url": "https://www.facebook.com/telenordanmark/posts/492241444121526"
+      "url": null
     },
     {
       "date": "2020-05-27",


### PR DESCRIPTION
## Summary
Audited all 75 outbound URLs (ISP + source links in `data/*.json`, plus the hardcoded page links). 53 OK, 16 benign redirects, 6 dead — 5 fixed here (the 6th was a false positive: glenten.dk geo-blocks non-Danish clients but is alive).

## Fixes
- **DeiC `/da/IPv6`** (404 after site restructure) → verified Wayback snapshot rendering the cited IPv6 page
- **nef.dk `fibernet-aendringer-2023`** (404) → verified Wayback snapshot
- **Glenten 2019 board-minutes PDF** (unreachable from outside DK) → Wayback snapshot serving the actual PDF
- **BornFiber 2015 tweet** — deleted, never archived → `url: null` (name + date remain as plain text)
- **Telenor Facebook post** — deleted; the only snapshot captured Facebook's "unavailable" page → `url: null`

All three snapshot links verified to render the cited content, not error shells. 36/36 unit tests pass, data validates.

Note: commit 3113ff8 on `mail-triage-data-fixes` is this same change, accidentally pushed there — safe to drop from that branch or ignore (identical content merges as a no-op).

🤖 Generated with [Claude Code](https://claude.com/claude-code)