### PR TITLE
ci: don't persist GITHUB_TOKEN in checkout steps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
+        with:
+          # No job pushes to the repo — don't leave GITHUB_TOKEN in git config.
+          persist-credentials: false
 
       - uses: actions/setup-node@v7
         with:
@@ -30,6 +33,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
+        with:
+          # No job pushes to the repo — don't leave GITHUB_TOKEN in git config.
+          persist-credentials: false
 
       - uses: actions/setup-node@v7
         with:


### PR DESCRIPTION
Aikido SAST flagged `actions/checkout` persisting the default `GITHUB_TOKEN` in the local git config (ci.yml). Neither CI job pushes to the repo, so set `persist-credentials: false` on both checkout steps — the token no longer lingers in git config where a later step or a compromised third-party action could read it.

Defense-in-depth on top of the existing `permissions: contents: read`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)