### PR TITLE
Tighten b2b schema contract and badge test assertions

### DIFF
--- a/e2e/smoke.spec.js
+++ b/e2e/smoke.spec.js
@@ -42,7 +42,9 @@ test('business-only ISPs carry the Erhverv badge, consumer ISPs do not', async (
   await search.fill('ipnordic');
   await expect(rows.first()).toContainText('ipnordic');
   const badge = rows.first().locator('.b2bBadge');
+  await expect(badge).toBeVisible();
   await expect(badge).toHaveText('Erhverv');
+  await expect(badge).toHaveAttribute('title', 'Leverer kun til erhvervskunder');
   expect(await rows.first().locator('a.ispLink .b2bBadge').count()).toBe(0);
 
   // Fiberby has no b2b field — no badge

--- a/schema.json
+++ b/schema.json
@@ -34,7 +34,7 @@
       "description": "Whether the ISP has IPv6-support, that only applies to a segmented customer group"
     },
     "b2b": {
-      "type": "boolean",
+      "const": true,
       "description": "Whether the ISP only serves business customers (erhverv). If the ISP also serves consumers, leave out this field."
     },
     "assignedprefix": {


### PR DESCRIPTION
## Background

Two reviewer findings on #153 arrived just as the PR merged, so they never made it into the branch. Both are small and uncontroversial; this PR lands them on `master`.

## Changes

- **`schema.json`**: `b2b` is now `"const": true` instead of `"type": "boolean"`. The documented contract is *true or omitted* — a record carrying `b2b: false` would pass CI but make presence-based consumers misclassify a consumer-facing provider. CI now rejects it. (Flagged by Greptile on #153.)
- **`e2e/smoke.spec.js`**: the Erhverv badge test now also asserts the badge is visible and carries the `Leverer kun til erhvervskunder` tooltip, alongside the existing text and placement checks. (Flagged by CodeRabbit on #153.)

## Validation

- `npx ajv-cli validate -s schema.json -d "data/*.json"` — all 50 files valid against the tightened schema.
- `npm test` — 36/36 data tests pass.
- `npm run build` + `npx playwright test` — all 7 e2e tests pass against the production build, including the strengthened badge assertions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DhDx74jkPZ7qQT174Vfafc

---
_Generated by [Claude Code](https://claude.ai/code/session_01DhDx74jkPZ7qQT174Vfafc)_