### PR TITLE
Anchor Flexii's IPv6 adoption date to its October 2022 launch

### DIFF
--- a/data/flexii.json
+++ b/data/flexii.json
@@ -3,10 +3,15 @@
   "name": "Flexii",
   "url": "https://www.flexii.dk",
   "ipv6": true,
-  "comment": "Flexii ejes af Hi3G Denmark (samme selskab som 3 og OiSTER) og kører på 3's mobilnet, der leverer IPv6/dual stack for udstyr, der understøtter det.",
+  "comment": "Flexii ejes af Hi3G Denmark (samme selskab som 3 og OiSTER) og kører på 3's mobilnet, der leverer IPv6/dual stack for udstyr, der understøtter det. Nettet har haft dual stack siden 2017, så Flexii har haft IPv6 siden lanceringen den 6. oktober 2022.",
   "partial": false,
   "technologies": ["mobile"],
   "sources": [
+    {
+      "date": "2022-10-06",
+      "name": "ITWatch: Teleselskabet 3 lancerer nyt lavpris-brand",
+      "url": "https://itwatch.dk/ITNyt/Brancher/tele/article14469674.ece"
+    },
     {
       "date": "2026-08-17",
       "name": "3: Vi fremtidssikrer netværket med Dual Stack IPv6",


### PR DESCRIPTION
## Background

Greptile flagged on #152 (just as it merged) that the adoption chart misplots Flexii: the chart uses each ISP's earliest source date, and both of Flexii's sources were dated 2026-08-17 — the day the entry was researched — so the chart showed Flexii adopting IPv6 in August 2026.

## Change

Flexii launched on 6 October 2022 on 3's network, which has been dual stack since November 2017 — its customers have had IPv6 from day one. This PR adds the launch-day [ITWatch article](https://itwatch.dk/ITNyt/Brancher/tele/article14469674.ece) as a dated source, which moves the chart point to the real adoption date, and notes the launch date in the comment.

## Validation

- `npx ajv-cli validate -s schema.json -d "data/*.json"` — all files valid.
- `npm test` — 36/36 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D9pfRzrTXSEDXJ2NR9Sbsp

---
_Generated by [Claude Code](https://claude.ai/code/session_01D9pfRzrTXSEDXJ2NR9Sbsp)_